### PR TITLE
feat: profile picture rounding, borders and improvements of QR code rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "lib"
   ],
   "dependencies": {
-    "qrcode-generator": "^1.4.3"
+    "qrcode-generator": "^1.4.3",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "@types/uuid": "^9.0.4",
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",
     "canvas": "^2.11.2",

--- a/src/core/QRCanvas.ts
+++ b/src/core/QRCanvas.ts
@@ -397,13 +397,33 @@ export default class QRCanvas {
     }
 
     const options = this._options;
+    const imageOptions = this._options.imageOptions;
     const xBeginning = Math.floor((options.width - count * dotSize) / 2);
     const yBeginning = Math.floor((options.height - count * dotSize) / 2);
-    const dx = xBeginning + options.imageOptions.margin + (count * dotSize - width) / 2;
-    const dy = yBeginning + options.imageOptions.margin + (count * dotSize - height) / 2;
-    const dw = width - options.imageOptions.margin * 2;
-    const dh = height - options.imageOptions.margin * 2;
+    const dx = xBeginning + imageOptions.margin + (count * dotSize - width) / 2;
+    const dy = yBeginning + imageOptions.margin + (count * dotSize - height) / 2;
+    const dw = width - imageOptions.margin * 2;
+    const dh = height - imageOptions.margin * 2;
 
+    // if (imageOptions.radius) {
+    //   const borderWidth = Math.max(imageOptions.borderWidth ?? 0, 0);
+    //   const borderColor = imageOptions.borderColor ?? "#ffffff";
+    //   const centerX = options.width / 2;
+    //   const centerY = options.width / 2;
+    //   const radius = imageOptions.radius + borderWidth;
+
+    //   // Draw the border around the circle
+    //   canvasContext.beginPath();
+    //   canvasContext.arc(centerX, centerY, radius, 0, 2 * Math.PI);
+    //   if (borderWidth > 0) {
+    //     canvasContext.lineWidth = borderWidth; // Set the border width
+    //     canvasContext.strokeStyle = borderColor; // Set the border color
+    //   }
+    //   canvasContext.stroke();
+
+    //   // Clip the canvas to the circular path
+    //   canvasContext.clip();
+    // }
     canvasContext.drawImage(this._image, dx, dy, dw < 0 ? 0 : dw, dh < 0 ? 0 : dh);
   }
 

--- a/src/core/QROptions.ts
+++ b/src/core/QROptions.ts
@@ -19,6 +19,9 @@ export interface RequiredOptions extends Options {
     imageSize: number;
     crossOrigin?: string;
     margin: number;
+    shape?: string;
+    borderWidth?: number;
+    borderColor?: string;
   };
   dotsOptions: {
     type: DotType;

--- a/src/core/QROptions.ts
+++ b/src/core/QROptions.ts
@@ -9,6 +9,10 @@ export interface RequiredOptions extends Options {
   height: number;
   margin: number;
   data: string;
+  /**
+   * See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering#usage_notes
+   */
+  shapeRendering?: string;
   qrOptions: {
     typeNumber: TypeNumber;
     mode?: Mode;

--- a/src/core/QRSVG.ts
+++ b/src/core/QRSVG.ts
@@ -44,6 +44,9 @@ export default class QRSVG {
     this._element.setAttribute("id", uuidv4());
     this._element.setAttribute("width", String(options.width));
     this._element.setAttribute("height", String(options.height));
+    if (options.shapeRendering) {
+      this._element.setAttribute("shape-rendering", options.shapeRendering);
+    }
     this._defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
     this._defs.setAttribute("id", uuidv4());
     this._element.appendChild(this._defs);
@@ -601,14 +604,13 @@ export default class QRSVG {
         }
 
         gradient = document.createElementNS("http://www.w3.org/2000/svg", "linearGradient");
-        gradient.setAttribute("id", gradientId);
         gradient.setAttribute("gradientUnits", "userSpaceOnUse");
         gradient.setAttribute("x1", String(Math.round(x0)));
         gradient.setAttribute("y1", String(Math.round(y0)));
         gradient.setAttribute("x2", String(Math.round(x1)));
         gradient.setAttribute("y2", String(Math.round(y1)));
       }
-
+      gradient.setAttribute("id", gradientId);
       options.colorStops.forEach(({ offset, color }: { offset: number; color: string }) => {
         const stop = document.createElementNS("http://www.w3.org/2000/svg", "stop");
         stop.setAttribute("offset", `${100 * offset}%`);

--- a/src/figures/cornerDot/svg/QRCornerDot.ts
+++ b/src/figures/cornerDot/svg/QRCornerDot.ts
@@ -1,6 +1,6 @@
 import cornerDotTypes from "../../../constants/cornerDotTypes";
 import { CornerDotType, RotateFigureArgs, BasicFigureDrawArgs, DrawArgs } from "../../../types";
-
+import { v4 as uuidv4 } from "uuid";
 export default class QRCornerDot {
   _element?: SVGElement;
   _svg: SVGElement;
@@ -42,6 +42,7 @@ export default class QRCornerDot {
       ...args,
       draw: () => {
         this._element = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+        this._element.setAttribute("id", uuidv4());
         this._element.setAttribute("cx", String(x + size / 2));
         this._element.setAttribute("cy", String(y + size / 2));
         this._element.setAttribute("r", String(size / 2));
@@ -56,6 +57,7 @@ export default class QRCornerDot {
       ...args,
       draw: () => {
         this._element = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+        this._element.setAttribute("id", uuidv4());
         this._element.setAttribute("x", String(x));
         this._element.setAttribute("y", String(y));
         this._element.setAttribute("width", String(size));

--- a/src/figures/cornerSquare/svg/QRCornerSquare.ts
+++ b/src/figures/cornerSquare/svg/QRCornerSquare.ts
@@ -1,5 +1,6 @@
 import cornerSquareTypes from "../../../constants/cornerSquareTypes";
 import { CornerSquareType, DrawArgs, BasicFigureDrawArgs, RotateFigureArgs } from "../../../types";
+import { v4 as uuidv4 } from "uuid";
 
 export default class QRCornerSquare {
   _element?: SVGElement;
@@ -46,6 +47,7 @@ export default class QRCornerSquare {
       ...args,
       draw: () => {
         this._element = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        this._element.setAttribute("id", uuidv4());
         this._element.setAttribute("clip-rule", "evenodd");
         this._element.setAttribute(
           "d",
@@ -68,6 +70,7 @@ export default class QRCornerSquare {
       ...args,
       draw: () => {
         this._element = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        this._element.setAttribute("id", uuidv4());
         this._element.setAttribute("clip-rule", "evenodd");
         this._element.setAttribute(
           "d",
@@ -94,6 +97,7 @@ export default class QRCornerSquare {
       ...args,
       draw: () => {
         this._element = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        this._element.setAttribute("id", uuidv4());
         this._element.setAttribute("clip-rule", "evenodd");
         this._element.setAttribute(
           "d",

--- a/src/figures/dot/svg/QRDot.ts
+++ b/src/figures/dot/svg/QRDot.ts
@@ -1,5 +1,6 @@
 import dotTypes from "../../../constants/dotTypes";
 import { DotType, GetNeighbor, DrawArgs, BasicFigureDrawArgs, RotateFigureArgs } from "../../../types";
+import { v4 as uuidv4 } from "uuid";
 
 export default class QRDot {
   _element?: SVGElement;
@@ -54,6 +55,7 @@ export default class QRDot {
       ...args,
       draw: () => {
         this._element = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+        this._element.setAttribute("id", uuidv4());
         this._element.setAttribute("cx", String(x + size / 2));
         this._element.setAttribute("cy", String(y + size / 2));
         this._element.setAttribute("r", String(size / 2));
@@ -68,6 +70,7 @@ export default class QRDot {
       ...args,
       draw: () => {
         this._element = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+        this._element.setAttribute("id", uuidv4());
         this._element.setAttribute("x", String(x));
         this._element.setAttribute("y", String(y));
         this._element.setAttribute("width", String(size));
@@ -84,6 +87,7 @@ export default class QRDot {
       ...args,
       draw: () => {
         this._element = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        this._element.setAttribute("id", uuidv4());
         this._element.setAttribute(
           "d",
           `M ${x} ${y}` + //go to top left position
@@ -103,6 +107,7 @@ export default class QRDot {
       ...args,
       draw: () => {
         this._element = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        this._element.setAttribute("id", uuidv4());
         this._element.setAttribute(
           "d",
           `M ${x} ${y}` + //go to top left position
@@ -123,6 +128,7 @@ export default class QRDot {
       ...args,
       draw: () => {
         this._element = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        this._element.setAttribute("id", uuidv4());
         this._element.setAttribute(
           "d",
           `M ${x} ${y}` + //go to top left position
@@ -142,6 +148,7 @@ export default class QRDot {
       ...args,
       draw: () => {
         this._element = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        this._element.setAttribute("id", uuidv4());
         this._element.setAttribute(
           "d",
           `M ${x} ${y}` + //go to left top position

--- a/src/index.html
+++ b/src/index.html
@@ -1,55 +1,79 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>QR Code Styling</title>
-    </head>
-    <body>
-        <div id="canvas"></div>
-        <div id="canvas2"></div>
-        <script type="text/javascript">
-            const options = {
-              width: 500,
-              height: 500,
-              data: "h",
-              image: "https://upload.wikimedia.org/wikipedia/commons/5/51/Facebook_f_logo_%282019%29.svg",
-              dotsOptions: {
-                type: "extra-rounded",
-                gradient: {
-                  type: "linear", //radial,
-                  rotation: Math.PI/2,
-                  colorStops: [{ offset: 0, color: 'blue' }, { offset: 0.5, color: 'red' }, { offset: 1, color: 'green' }]
-                },
-              },
-              cornersSquareOptions: {
-                type: "rounded",
-                gradient: {
-                  type: "linear",
-                  rotation: Math.PI * 0.2,
-                  colorStops: [{
-                    offset: 0,
-                    color: 'blue'
-                  }, {
-                    offset: 1,
-                    color: 'red'
-                  }]
-                },
-              },
-              imageOptions: {
-                crossOrigin: "anonymous",
-                margin: 30
-              }
-            };
-          const qrCode = new QRCodeStyling(options);
-          const qrCode2 = new QRCodeStyling({
-            ...options,
-            type: 'svg',
-          });
 
-            qrCode.append(document.getElementById("canvas"));
-            qrCode2.append(document.getElementById("canvas2"));
+<head>
+  <meta charset="UTF-8">
+  <title>QR Code Styling</title>
+</head>
 
-            // qrCode2.download()
-        </script>
-    </body>
+<body>
+  <div id="canvas"></div>
+  <div id="canvas2"></div>
+  <div id="canvas3"></div>
+  <script async type="text/javascript">
+    console.log("This script must load last")
+    const options = {
+      width: 500,
+      height: 500,
+      data: "eip155:0xcafecafecafecafecafecafecafecafecafecafe:2828",
+      type: 'canvas', // 'canvas' is default value but setting here for clarity
+      // This URL holds a rectangular (horizontal) image 
+      //image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Fibonacci_Squares.svg/1200px-Fibonacci_Squares.svg.png",
+      image: "https://2eff.lukso.dev/ipfs/QmS4Sb1bWC2xiDPfHvqV8urpzwjUQioqrzKRCXdmSNpDXA",
+      dotsOptions: {
+        type: "rounded",
+        gradient: {
+          type: "linear", //radial,
+          rotation: Math.PI / 4,
+          colorStops: [{ offset: 0, color: 'blue' }, { offset: 0.5, color: 'red' }, { offset: 1, color: 'green' }]
+        },
+      },
+      cornersSquareOptions: {
+        type: "rounded",
+        gradient: {
+          type: "linear",
+          rotation: Math.PI * 0.2,
+          colorStops: [{
+            offset: 0,
+            color: 'blue'
+          }, {
+            offset: 1,
+            color: 'red'
+          }]
+        },
+      },
+      imageOptions: {
+        imageSize: 0.18,
+        crossOrigin: "anonymous",
+        shape: 'circle',
+        borderWidth: 7,
+        borderColor: '#ffffff'
+      }
+    };
+    const qrCode = new QRCodeStyling(options);
+    const qrCode2 = new QRCodeStyling({
+      ...options,
+      type: 'svg',
+    });
+    const qrCode3 = new QRCodeStyling({
+      ...options,
+      dotsOptions: {
+        type: "extra-rounded",
+        color: "black"
+      },
+      cornersSquareOptions: {
+        type: "extra-rounded",
+        color: "black"
+      },
+      type: 'svg',
+    });
+
+    qrCode.append(document.getElementById("canvas"));
+    qrCode2.append(document.getElementById("canvas2"));
+    qrCode3.append(document.getElementById("canvas3"));
+
+    // qrCode2.download()
+  </script>
+</body>
+
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -53,10 +53,12 @@
     const qrCode = new QRCodeStyling(options);
     const qrCode2 = new QRCodeStyling({
       ...options,
+      data: options.data + Math.random(),
       type: 'svg',
     });
     const qrCode3 = new QRCodeStyling({
       ...options,
+      data: options.data + Math.random(),
       dotsOptions: {
         type: "extra-rounded",
         color: "black"
@@ -69,6 +71,7 @@
     });
     const qrCode4 = new QRCodeStyling({
       ...options,
+      data: options.data + Math.random(),
       image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Fibonacci_Squares.svg/1200px-Fibonacci_Squares.svg.png",
       dotsOptions: {
         color: "black"
@@ -86,6 +89,7 @@
     });
     const qrCode5 = new QRCodeStyling({
       ...options,
+      data: options.data + Math.random(),
       image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Fibonacci_Squares.svg/1200px-Fibonacci_Squares.svg.png",
       dotsOptions: {
         color: "black"

--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,8 @@
   <div id="canvas"></div>
   <div id="canvas2"></div>
   <div id="canvas3"></div>
+  <div id="canvas4"></div>
+  <div id="canvas5"></div>
   <script async type="text/javascript">
     console.log("This script must load last")
     const options = {
@@ -17,8 +19,6 @@
       height: 500,
       data: "eip155:0xcafecafecafecafecafecafecafecafecafecafe:2828",
       type: 'canvas', // 'canvas' is default value but setting here for clarity
-      // This URL holds a rectangular (horizontal) image 
-      //image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Fibonacci_Squares.svg/1200px-Fibonacci_Squares.svg.png",
       image: "https://2eff.lukso.dev/ipfs/QmS4Sb1bWC2xiDPfHvqV8urpzwjUQioqrzKRCXdmSNpDXA",
       dotsOptions: {
         type: "rounded",
@@ -67,10 +67,46 @@
       },
       type: 'svg',
     });
+    const qrCode4 = new QRCodeStyling({
+      ...options,
+      image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Fibonacci_Squares.svg/1200px-Fibonacci_Squares.svg.png",
+      dotsOptions: {
+        color: "black"
+      },
+      imageOptions: {
+        imageSize: 0.40,
+        crossOrigin: "anonymous",
+        borderWidth: 10,
+        borderColor: "red"
+      },
+      cornersSquareOptions: {
+        color: "black"
+      },
+      type: 'svg',
+    });
+    const qrCode5 = new QRCodeStyling({
+      ...options,
+      image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Fibonacci_Squares.svg/1200px-Fibonacci_Squares.svg.png",
+      dotsOptions: {
+        color: "black"
+      },
+      imageOptions: {
+        imageSize: 0.80,
+        crossOrigin: "anonymous",
+        borderWidth: 40,
+        borderColor: "blue"
+      },
+      cornersSquareOptions: {
+        color: "black"
+      },
+      type: 'svg',
+    });
 
     qrCode.append(document.getElementById("canvas"));
     qrCode2.append(document.getElementById("canvas2"));
     qrCode3.append(document.getElementById("canvas3"));
+    qrCode4.append(document.getElementById("canvas4"));
+    qrCode5.append(document.getElementById("canvas5"));
 
     // qrCode2.download()
   </script>

--- a/src/index.html
+++ b/src/index.html
@@ -53,11 +53,13 @@
     const qrCode = new QRCodeStyling(options);
     const qrCode2 = new QRCodeStyling({
       ...options,
-      data: options.data + Math.random(),
+      shapeRendering: "geometricPrecision",
+      data: options.data + Math.random() + Math.random() + Math.random() + Math.random() + Math.random(),
       type: 'svg',
     });
     const qrCode3 = new QRCodeStyling({
       ...options,
+      shapeRendering: "geometricPrecision",
       data: options.data + Math.random(),
       dotsOptions: {
         type: "extra-rounded",
@@ -72,6 +74,8 @@
     const qrCode4 = new QRCodeStyling({
       ...options,
       data: options.data + Math.random(),
+      // Use "crispEdges" to resolve issue with white lines appearing between squares/dots of a QR code
+      shapeRendering: "crispEdges",
       image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Fibonacci_Squares.svg/1200px-Fibonacci_Squares.svg.png",
       dotsOptions: {
         color: "black"

--- a/yarn.lock
+++ b/yarn.lock
@@ -930,6 +930,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.3.tgz#3d06b6769518450871fbc40770b7586334bdfd90"
   integrity sha512-THo502dA5PzG/sfQH+42Lw3fvmYkceefOspdCwpHRul8ik2Jv1K8I5OZz1AT3/rs46kwgMCe9bSBmDLYkkOMGg==
 
+"@types/uuid@^9.0.4":
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.4.tgz#e884a59338da907bda8d2ed03e01c5c49d036f1c"
+  integrity sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==
+
 "@types/ws@^8.5.5":
   version "8.5.6"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.6.tgz#e9ad51f0ab79b9110c50916c9fcbddc36d373065"
@@ -5183,6 +5188,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache@^2.0.3:
   version "2.4.0"


### PR DESCRIPTION
- Added an option of rounding a picture we show in the middle;
- Image is centred if it's not a square;
- We can add a border and set its colour;
- Multiple SVG type QR codes can be rendered on the same screen. Fix was to use different `id` attributes for SVG elements;
- improved QR code rendering a round a circular image (see before and after pictures below)
Before (notice empty corners around the center picture):
![Screenshot 2023-10-05 at 10 56 22](https://github.com/JeneaVranceanu/qr-code-styling/assets/36865532/f3cae82c-1e83-4a68-a0c6-cec15eda1c20)

After (corners now filled):
![Screenshot 2023-10-05 at 10 56 12](https://github.com/JeneaVranceanu/qr-code-styling/assets/36865532/dc2ce8af-cdaf-4ff0-9386-c7613ab3940e)

An "after" example with more data in the QR code:
![Screenshot 2023-10-05 at 10 49 01](https://github.com/JeneaVranceanu/qr-code-styling/assets/36865532/0d5bca47-d159-4351-9e46-e999dad30080)


<img width="520" alt="Screenshot 2023-10-06 at 00 33 00" src="https://github.com/JeneaVranceanu/qr-code-styling/assets/36865532/e7342b66-a019-4182-821a-084e7d1f447c">
<img width="518" alt="Screenshot 2023-10-06 at 00 32 49" src="https://github.com/JeneaVranceanu/qr-code-styling/assets/36865532/594c15ef-4a37-4613-b088-573d367c6114">